### PR TITLE
Update gatsby-config.js

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,147 +1,32 @@
-require(`dotenv`).config()
-
-const shouldAnalyseBundle = process.env.ANALYSE_BUNDLE
-
-module.exports = {
-  siteMetadata: {
-    // You can overwrite values here that are used for the SEO component
-    // You can also add new values here to query them like usual
-    // See all options: https://github.com/LekoArts/gatsby-themes/blob/main/themes/gatsby-theme-minimal-blog/gatsby-config.js
-    siteTitle: `Minimal Blog`,
-    siteTitleAlt: `Minimal Blog - Gatsby Theme`,
-    siteHeadline: `Minimal Blog - Gatsby Theme from @lekoarts`,
-    siteUrl: `https://minimal-blog.lekoarts.de`,
-    siteDescription: `Typography driven, feature-rich blogging theme with minimal aesthetics. Includes tags/categories support and extensive features for code blocks such as live preview, line numbers, and line highlighting.`,
-    siteLanguage: `en`,
-    siteImage: `/banner.jpg`,
-    author: `@lekoarts_de`,
-  },
-  plugins: [
-    {
-      resolve: `@lekoarts/gatsby-theme-minimal-blog`,
-      // See the theme's README for all available options
-      options: {
-        navigation: [
-          {
-            title: `Blog`,
-            slug: `/blog`,
-          },
-          {
-            title: `About`,
-            slug: `/about`,
-          },
-        ],
-        externalLinks: [
-          {
-            name: `Twitter`,
-            url: `https://twitter.com/lekoarts_de`,
-          },
-          {
-            name: `Homepage`,
-            url: `https://www.lekoarts.de?utm_source=minimal-blog&utm_medium=Starter`,
-          },
-        ],
-      },
-    },
-    {
-      resolve: `gatsby-omni-font-loader`,
-      options: {
-        enableListener: true,
-        preconnect: [`https://fonts.gstatic.com`],
-        // If you plan on changing the font you'll also need to adjust the Theme UI config to edit the CSS
-        // See: https://github.com/LekoArts/gatsby-themes/tree/main/examples/minimal-blog#changing-your-fonts
-        web: [
-          {
-            name: `IBM Plex Sans`,
-            file: `https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap`,
-          },
-        ],
-      },
-    },
-    `gatsby-plugin-sitemap`,
-    {
-      resolve: `gatsby-plugin-manifest`,
-      options: {
-        name: `minimal-blog - @lekoarts/gatsby-theme-minimal-blog`,
-        short_name: `minimal-blog`,
-        description: `Typography driven, feature-rich blogging theme with minimal aesthetics. Includes tags/categories support and extensive features for code blocks such as live preview, line numbers, and code highlighting.`,
-        start_url: `/`,
-        background_color: `#fff`,
-        // This will impact how browsers show your PWA/website
-        // https://css-tricks.com/meta-theme-color-and-trickery/
-        // theme_color: `#6B46C1`,
-        display: `standalone`,
-        icons: [
-          {
-            src: `/android-chrome-192x192.png`,
-            sizes: `192x192`,
-            type: `image/png`,
-          },
-          {
-            src: `/android-chrome-512x512.png`,
-            sizes: `512x512`,
-            type: `image/png`,
-          },
-        ],
-      },
-    },
-    {
-      resolve: `gatsby-plugin-feed`,
-      options: {
-        query: `
-          {
-            site {
-              siteMetadata {
-                title: siteTitle
-                description: siteDescription
-                siteUrl
-                site_url: siteUrl
-              }
-            }
-          }
-        `,
-        feeds: [
-          {
-            serialize: ({ query: { site, allPost } }) =>
-              allPost.nodes.map((post) => {
-                const url = site.siteMetadata.siteUrl + post.slug
-                const content = `<p>${post.excerpt}</p><div style="margin-top: 50px; font-style: italic;"><strong><a href="${url}">Keep reading</a>.</strong></div><br /> <br />`
-
-                return {
-                  title: post.title,
-                  date: post.date,
-                  excerpt: post.excerpt,
-                  url,
-                  guid: url,
-                  custom_elements: [{ "content:encoded": content }],
-                }
-              }),
-            query: `
-              {
-                allPost(sort: { fields: date, order: DESC }) {
-                  nodes {
-                    title
-                    date(formatString: "MMMM D, YYYY")
-                    excerpt
-                    slug
-                  }
-                }
-              }
-            `,
-            output: `rss.xml`,
-            title: `Minimal Blog - @lekoarts/gatsby-theme-minimal-blog`,
-          },
-        ],
-      },
-    },
-    `gatsby-plugin-gatsby-cloud`,
-    shouldAnalyseBundle && {
-      resolve: `gatsby-plugin-webpack-bundle-analyser-v2`,
-      options: {
-        analyzerMode: `static`,
-        reportFilename: `_bundle.html`,
-        openAnalyzer: false,
-      },
-    },
-  ].filter(Boolean),
-}
+System:
+    OS: macOS 12.4
+    CPU: (12) x64 Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+    Shell: 3.2.57 - /bin/sh
+  Binaries:
+    Node: 14.18.2 - ~/.nvm/versions/node/v14.18.2/bin/node
+    Yarn: 1.22.19 - /usr/local/bin/yarn
+    npm: 6.14.15 - ~/.nvm/versions/node/v14.18.2/bin/npm
+  Browsers:
+    Chrome: 102.0.5005.115
+    Edge: 102.0.1245.44
+    Firefox: 101.0.1
+    Safari: 15.5
+  npmPackages:
+    gatsby: ^4.17.0 => 4.17.0
+    gatsby-cli: ^4.17.0 => 4.17.0
+    gatsby-plugin-feed: ^4.17.0 => 4.17.0
+    gatsby-plugin-gatsby-cloud: ^4.17.0 => 4.17.0
+    gatsby-plugin-google-analytics: ^4.17.0 => 4.17.0
+    gatsby-plugin-image: ^2.17.0 => 2.17.0
+    gatsby-plugin-manifest: ^4.17.0 => 4.17.0
+    gatsby-plugin-offline: ^5.17.0 => 5.17.0
+    gatsby-plugin-react-helmet: ^5.17.0 => 5.17.0
+    gatsby-plugin-sharp: ^4.17.0 => 4.17.0
+    gatsby-remark-copy-linked-files: ^5.17.0 => 5.17.0
+    gatsby-remark-images: ^6.17.0 => 6.17.0
+    gatsby-remark-prismjs: ^6.17.0 => 6.17.0
+    gatsby-remark-responsive-iframe: ^5.17.0 => 5.17.0
+    gatsby-remark-smartypants: ^5.17.0 => 5.17.0
+    gatsby-source-filesystem: ^4.17.0 => 4.17.0
+    gatsby-transformer-remark: ^5.17.0 => 5.17.0
+    gatsby-transformer-sharp: ^4.17.0 => 4.17.0


### PR DESCRIPTION
เมื่อใช้gatsby-remark-imagesและระบุ a maxWidthและsrcSetBreakpointsหลายรูปแบบ รูปภาพต้นฉบับจะถูกรวมและเข้ารหัสในทุกรูปแบบเสมอ แม้ว่าจะมีขนาดใหญ่กว่าmaxWidth. ซึ่งอาจมีราคาแพงมากเมื่อใช้รูปแบบที่มีความต้องการสูง เช่น.avifและ/หรือเมื่อภาพต้นฉบับมีขนาดใหญ่

ดูเหมือนว่ามีการตั้งสมมติฐานว่าภาพต้นฉบับจะมีความกว้างเท่ากับขนาดภาพใหญ่เสมอซึ่งเป็นข้อสันนิษฐานที่ผิด เป็นเรื่องปกติที่จะใช้อิมเมจต้นฉบับที่ใหญ่ขึ้น ไม่ว่าจะเพื่อการพิสูจน์อักษรในอนาคตหรือเพื่อการเข้ารหัสที่ดีขึ้น